### PR TITLE
Support for Calendar Versioning (Calver)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python
 import os
 
-from distutils.core import setup
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
 
 SCRIPT_DIR = os.path.dirname(__file__)
 if not SCRIPT_DIR:
@@ -14,7 +17,7 @@ setup(name='tag-version',
       author='Roberto Aguilar',
       author_email='roberto.c.aguilar@gmail.com',
       url='https://github.com/rca/tag-version',
-      package_dir = {'': 'src'},
+      package_dir={'': 'src'},
       packages=['tagversion'],
       install_requires=[
         'sh',
@@ -23,5 +26,4 @@ setup(name='tag-version',
           'console_scripts': [
               'tag-version = tagversion.entrypoints:main'
           ]
-      },
-)
+      },)

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -11,8 +11,6 @@ import sys
 
 from .exceptions import BranchError, VersionError
 
-# SEMVER_RE = re.compile(r'^[0-9]+\.[0-9]+\.[0-9]+$')
-
 '''
     Uses a slightly modified version of this regex
     https://regex101.com/r/E0iVVS/2
@@ -67,7 +65,8 @@ class GitVersion(object):
 
             color_marker_idx = branch.find('\x1b')
             if color_marker_idx >= 0:
-                self.logger.warning('found color marker in branch={}'.format(branch.encode("utf8")))
+                self.logger.warning('found color marker in branch={}'.format(
+                    branch.encode("utf8")))
                 branch = branch[:color_marker_idx]
 
         # clean string to remove unwanted characters
@@ -126,11 +125,13 @@ class GitVersion(object):
         else:
             version = command.stdout.decode('utf8').strip()
 
-            # if the branch flag was given, check to see if we are on a tagged commit
+            # if the branch flag was given,
+            # check to see if we are on a tagged commit
             if self.args.branch:
                 try:
                     command = sh.git(*shlex.split('describe --tags --exact-match'))
-                except sh.ErrorReturnCode_128:  # not an exact match, so append the branch
+                except sh.ErrorReturnCode_128:
+                    # not an exact match, so append the branch
                     version = '{}-{}'.format(version, self.branch)
 
             return version
@@ -201,9 +202,11 @@ class GitVersion(object):
         now = datetime.now().strftime(self.args.calver_format)
         # split the current date
         split_calver = now.split('.', 2)
+        for i in range(2):
+            split_calver[i] = int(split_calver[i])
+
         # split the version and int'ify major, minor, and patch
         split_version = version.split('-', 1)[0].split('.', 3)
-
         for i in range(3):
             split_version[i] = int(split_version[i])
 
@@ -221,7 +224,7 @@ class GitVersion(object):
         elif self.args.patch:
             # if we are on the same day bump the patch
             # otherwise move to the new date
-            if (now == split_version[:2]):
+            if (split_calver == split_version[:2]):
                 split_version[PATCH] += 1
                 split_calver.append(split_version[PATCH])
             else:
@@ -307,7 +310,7 @@ class GitVersion(object):
                 status = 1
         else:
             version_str = self.stringify(new_version)
-            # os.system(' '.join(['git', 'tag', '-a', version_str]))
+            os.system(' '.join(['git', 'tag', '-a', version_str]))
 
             print(version_str)
 

--- a/src/tagversion/git.py
+++ b/src/tagversion/git.py
@@ -207,10 +207,17 @@ class GitVersion(object):
         for i in range(3):
             split_version[i] = int(split_version[i])
 
+        # don't allow major/minor
         if self.args.major:
-            raise VersionError('You can not bump to a major calver release.')
+            raise VersionError('''
+                You can not bump to a major calver release.
+                If you want to override this use `--set --force` instead
+                ''')
         elif self.args.minor:
-            raise VersionError('You can not bump to a minor calver release.')
+            raise VersionError('''
+                You can not bump to a minor calver release.
+                If you want to override this use `--set --force` instead
+                ''')
         elif self.args.patch:
             # if we are on the same day bump the patch
             # otherwise move to the new date


### PR DESCRIPTION
This will add support for a calender-based versioning system, or calver. http://calver.org/

The default formatting will be `YYYYMM.DD.x`. 

In order to use the calver functionality the `--calver` tag must be applied.

A few things to note:
- a `--calver` bump will either set the version to the current date w/ a `.0` patch if the last version was a previous data, or increment the patch number if the previous version is of the current date.
- `--calver` will NOT support `--major` or `--minor` bumps
- `--calver` will accept a `--set` if you want to override (for example, create a version in the past or future - not reccommended0
- you can use `--calver-format` to specify a different formatting scheme (for example, `YY.MM`